### PR TITLE
feat: Detect old version 20.1.1

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -59,7 +59,7 @@
 								action: "template",
 								name: path
 							}), "*");
-						} else if (contents.indexOf("mxGraphModel") === -1) {
+						} else if (contents.indexOf("mxGraphModel") === -1 && contents.indexOf("mxfile") === -1) {
 							// If the contents is something else, we just error and exit
 							OC.Notification.show(t(OCA.Drawio.AppName, "Error: This is not a Drawio file!"));
 						} else {


### PR DESCRIPTION
Allow opening fold files containing diagrams in a Base64 encoded string.

Detect old diagram files with format:

```xml
<mxfile host="embed.diagrams.net" modified="2022-07-18T07:48:57.630Z" agent="5.0 (Windows)" etag="ipYgSYZ8rPu_ODWWGAQg" version="20.1.1" type="embed">
    <diagram id="0EaPF9thoUGu20jJeT-k" name="Page-1">
        base64 compressed data
    </diagram>
</mxfile>
```

### Explanation
Prior to v21.1.0, drawio was saving files in compressed format. This means, the `mxGraphModel` never appeared in the file before.
Since v21.1.0, the files are stored in the uncompressed format.

See changelog:

https://github.com/jgraph/drawio/blob/c7ac634055c3edfabc7729fc4298a5ab7bfbf384/ChangeLog#L125-L131

**Note:** Found interesting fix in another project affected by the change.
https://github.com/weseek/growi/pull/7537