### PR TITLE
fix: set minimum version for draw.io app to 10.5

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@
 	<summary>Integration of Draw.io editor into ownCloud Files app for creating and modifying diagrams</summary>
 	<screenshot>https://raw.githubusercontent.com/owncloud/drawio/master/screenshot.png</screenshot>
 	<dependencies>
-		<owncloud min-version="10.0" max-version="10" />
+		<owncloud min-version="10.5" max-version="10" />
 	</dependencies>
 	<bugs>https://github.com/owncloud/drawio/issues</bugs>
 	<repository type="git">https://github.com/owncloud/drawio.git</repository>


### PR DESCRIPTION
refs #18 

OC.Files.Client::lock() was introduced in 10.5