### PR TITLE
fix: paths will be urlencoded by the js client

### DIFF
--- a/templates/editor.php
+++ b/templates/editor.php
@@ -43,7 +43,7 @@ style('drawio', 'editor');
 	window.addEventListener('DOMContentLoaded', function() {
 		OCA.Drawio.LoadEventHandler(
 			$('#drawioEditor')[0].contentWindow,
-			'<?php echo urldecode($_['path']); ?>',
+			'<?php echo $_['path']; ?>',
 			'https://embed.diagrams.net'
 		);
 	});


### PR DESCRIPTION
Related to https://github.com/owncloud/core/pull/41380

Need to raw path. The js client will take care of url-encode the path to perform operations from the editor.