### PR TITLE
chore: use reusable build workflow for make dist

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,9 +50,4 @@ jobs:
     name: Build
     needs:
       - php-code-style
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Build
-        run: make dist
+    uses: owncloud/reusable-workflows/.github/workflows/build.yml@main


### PR DESCRIPTION
Adopts the reusable `build` workflow from [owncloud/reusable-workflows](https://github.com/owncloud/reusable-workflows) to run `make dist` in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)